### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bgruening @conda-forge/r @daler @dpryan79 @jdblischak @johanneskoester @sebastian-luna-valero
+* @conda-forge/r @sebastian-luna-valero

--- a/README.md
+++ b/README.md
@@ -169,11 +169,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@bgruening](https://github.com/bgruening/)
 * [@conda-forge/r](https://github.com/conda-forge/r/)
-* [@daler](https://github.com/daler/)
-* [@dpryan79](https://github.com/dpryan79/)
-* [@jdblischak](https://github.com/jdblischak/)
-* [@johanneskoester](https://github.com/johanneskoester/)
 * [@sebastian-luna-valero](https://github.com/sebastian-luna-valero/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,9 +52,4 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-    - dpryan79
     - sebastian-luna-valero
-    - johanneskoester
-    - bgruening
-    - daler
-    - jdblischak


### PR DESCRIPTION

Remove individually listed maintainers that are members of the conda-forge/r team

Followed a similar strategy from the docs for updating the maintainers. Unfortunately it doesn't appear possible to skip the CI jobs in the PR itself, even the example PR had jobs run

https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list
